### PR TITLE
fix loading decorator config from file

### DIFF
--- a/mmc_code/mmcensor/gui/gui_ctk.py
+++ b/mmc_code/mmcensor/gui/gui_ctk.py
@@ -304,12 +304,12 @@ class mmc_gui_ctk:
             print(f"Error loading file: {e}")
             return
 
-        self.close_decorator_config()
-        self.current_decorator_index = -1
         for elt in self.decorators_gui:
             elt.destroy()
+        self.decorators_gui.clear()
         self.rt.decorators.clear()
         self.decorator_types.clear()
+        self.current_decorator_index = -1
 
         for elt in save_data:
             self.add_decorator(elt[0])

--- a/mmc_code/mmcensor/rt/rt.py
+++ b/mmc_code/mmcensor/rt/rt.py
@@ -66,7 +66,7 @@ class mmc_screencap:
         l = t = r = b = None
         for cam in self.cams:
             l = cam['cam_coords'][0] if l is None else min( l, cam['cam_coords'][0] )
-            t = cam['cam_coords'][1] if t is None else min( l, cam['cam_coords'][1] )
+            t = cam['cam_coords'][1] if t is None else min( t, cam['cam_coords'][1] )
             r = cam['cam_coords'][2] if r is None else max( r, cam['cam_coords'][2] )
             b = cam['cam_coords'][3] if b is None else max( b, cam['cam_coords'][3] )
 


### PR DESCRIPTION
loading from a file was giving "bad window path name" Tkinter errors, so I changed the load_from logic to match load_pushed, which seems to fix it

the change in rt.py is a small copy-paste error that Claude Sonnet found